### PR TITLE
indicate failure to export functions, rather than return null in top level

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -23,9 +23,9 @@
       }
     },
     "node_modules/ansi-regex": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
-      "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.1.tgz",
+      "integrity": "sha512-+O9Jct8wf++lXxxFc4hc8LsjaSq0HFzzL7cVsw8pRDIPdjKD2mT4ytDZlLuSBZ4cLKZFXIrMGO7DbQCtMJJMKw==",
       "engines": {
         "node": ">=4"
       }
@@ -154,9 +154,9 @@
       }
     },
     "node_modules/cliui/node_modules/ansi-regex": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
-      "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.1.tgz",
+      "integrity": "sha512-ILlv4k/3f6vfQ4OoP2AGvirOktlQ98ZEL1k9FaQjxa3L1abBgbuTDAdPOpvbGncC0BTVQrl+OM8xZGK6tWXt7g==",
       "engines": {
         "node": ">=6"
       }
@@ -215,7 +215,7 @@
     "node_modules/decamelize": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
-      "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=",
+      "integrity": "sha512-z2S+W9X73hAUUki+N+9Za2lBlun89zigOyGrsax+KUQ6wKW4ZoWpEYBkGhQjwAjjDCkWxhY0VKEhk8wzY7F5cA==",
       "engines": {
         "node": ">=0.10.0"
       }
@@ -327,10 +327,9 @@
       }
     },
     "node_modules/flat": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/flat/-/flat-4.1.0.tgz",
-      "integrity": "sha512-Px/TiLIznH7gEDlPXcUD4KnBusa6kR6ayRUVcnEAbreRIuhkqow/mun59BuRXwoYk7ZQOLW1ZM05ilIvK38hFw==",
-      "deprecated": "Fixed a prototype pollution security issue in 4.1.0, please upgrade to ^4.1.1 or ^5.0.1.",
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/flat/-/flat-4.1.1.tgz",
+      "integrity": "sha512-FmTtBsHskrU6FJ2VxCnsDb84wu9zhmO3cUX2kGFb5tuwhfXxGciiT0oRY+cck35QmG+NmGh5eLz6lLCpWTqwpA==",
       "dependencies": {
         "is-buffer": "~2.0.3"
       },
@@ -357,9 +356,9 @@
       }
     },
     "node_modules/get-func-name": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/get-func-name/-/get-func-name-2.0.0.tgz",
-      "integrity": "sha1-6td0q+5y4gQJQzoGY2YCPdaIekE=",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/get-func-name/-/get-func-name-2.0.2.tgz",
+      "integrity": "sha512-8vXOvuE167CtIc3OyItco7N/dpRtBbYOsPsXCz7X/PMnlGjYjSGuZJgM1Y7mmew7BKf9BqvLX2tnOVy1BBUsxQ==",
       "engines": {
         "node": "*"
       }
@@ -530,9 +529,9 @@
       }
     },
     "node_modules/lodash": {
-      "version": "4.17.15",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
-      "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A=="
+      "version": "4.17.21",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
     },
     "node_modules/log-symbols": {
       "version": "2.2.0",
@@ -557,26 +556,29 @@
       }
     },
     "node_modules/minimist": {
-      "version": "0.0.8",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
-      "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
+      "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
     },
     "node_modules/mkdirp": {
-      "version": "0.5.1",
-      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
-      "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+      "version": "0.5.4",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.4.tgz",
+      "integrity": "sha512-iG9AK/dJLtJ0XNgTuDbSyNS3zECqDlAhnQW4CsNxBG3LQJBbHmRX1egw39DmtOdCAqY+dKXV+sgPgilNWUKMVw==",
       "deprecated": "Legacy versions of mkdirp are no longer supported. Please update to mkdirp 1.x. (Note that the API surface has changed to use Promises in 1.x.)",
       "dependencies": {
-        "minimist": "0.0.8"
+        "minimist": "^1.2.5"
       },
       "bin": {
         "mkdirp": "bin/cmd.js"
       }
     },
     "node_modules/mocha": {
-      "version": "6.2.2",
-      "resolved": "https://registry.npmjs.org/mocha/-/mocha-6.2.2.tgz",
-      "integrity": "sha512-FgDS9Re79yU1xz5d+C4rv1G7QagNGHZ+iXF81hO8zY35YZZcLEsJVfFolfsqKFWunATEvNzMK0r/CwWd/szO9A==",
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/mocha/-/mocha-6.2.3.tgz",
+      "integrity": "sha512-0R/3FvjIGH3eEuG17ccFPk117XL2rWxatr81a57D+r/x2uTYZRbdZ4oVidEUMh2W2TJDa7MdAb12Lm2/qrKajg==",
       "dependencies": {
         "ansi-colors": "3.2.3",
         "browser-stdout": "1.3.1",
@@ -590,7 +592,7 @@
         "js-yaml": "3.13.1",
         "log-symbols": "2.2.0",
         "minimatch": "3.0.4",
-        "mkdirp": "0.5.1",
+        "mkdirp": "0.5.4",
         "ms": "2.1.1",
         "node-environment-flags": "1.0.5",
         "object.assign": "4.1.0",
@@ -598,8 +600,8 @@
         "supports-color": "6.0.0",
         "which": "1.3.1",
         "wide-align": "1.1.3",
-        "yargs": "13.3.0",
-        "yargs-parser": "13.1.1",
+        "yargs": "13.3.2",
+        "yargs-parser": "13.1.2",
         "yargs-unparser": "1.6.0"
       },
       "bin": {
@@ -724,9 +726,9 @@
       }
     },
     "node_modules/pathval": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/pathval/-/pathval-1.1.0.tgz",
-      "integrity": "sha1-uULm1L3mUwBe9rcTYd74cn0GReA=",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/pathval/-/pathval-1.1.1.tgz",
+      "integrity": "sha512-Dp6zGqpTdETdR63lehJYPeIOqpiNBNtc7BpWSLrOje7UaIsE5aY92r/AunQA7rsXvet3lrJ3JnZX29UPTKXyKQ==",
       "engines": {
         "node": "*"
       }
@@ -745,9 +747,9 @@
       "integrity": "sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg=="
     },
     "node_modules/semver": {
-      "version": "5.7.1",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-      "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+      "version": "5.7.2",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.2.tgz",
+      "integrity": "sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==",
       "bin": {
         "semver": "bin/semver"
       }
@@ -874,9 +876,9 @@
       }
     },
     "node_modules/wrap-ansi/node_modules/ansi-regex": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
-      "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.1.tgz",
+      "integrity": "sha512-ILlv4k/3f6vfQ4OoP2AGvirOktlQ98ZEL1k9FaQjxa3L1abBgbuTDAdPOpvbGncC0BTVQrl+OM8xZGK6tWXt7g==",
       "engines": {
         "node": ">=6"
       }
@@ -911,14 +913,14 @@
       "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
     },
     "node_modules/y18n": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.0.tgz",
-      "integrity": "sha512-r9S/ZyXu/Xu9q1tYlpsLIsa3EeLXXk0VwlxqTcFRfg9EhMW+17kbt9G0NrgCmhGb5vT2hyhJZLfDGx+7+5Uj/w=="
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.3.tgz",
+      "integrity": "sha512-JKhqTOwSrqNA1NY5lSztJ1GrBiUodLMmIZuLiDaMRJ+itFd+ABVE8XBjOvIWL+rSqNDC74LCSFmlb/U4UZ4hJQ=="
     },
     "node_modules/yargs": {
-      "version": "13.3.0",
-      "resolved": "https://registry.npmjs.org/yargs/-/yargs-13.3.0.tgz",
-      "integrity": "sha512-2eehun/8ALW8TLoIl7MVaRUrg+yCnenu8B4kBlRxj3GJGDKU1Og7sMXPNm1BYyM1DOJmTZ4YeN/Nwxv+8XJsUA==",
+      "version": "13.3.2",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-13.3.2.tgz",
+      "integrity": "sha512-AX3Zw5iPruN5ie6xGRIDgqkT+ZhnRlZMLMHAs8tg7nRruy2Nb+i5o9bwghAogtM08q1dpr2LVoS8KSTMYpWXUw==",
       "dependencies": {
         "cliui": "^5.0.0",
         "find-up": "^3.0.0",
@@ -929,13 +931,13 @@
         "string-width": "^3.0.0",
         "which-module": "^2.0.0",
         "y18n": "^4.0.0",
-        "yargs-parser": "^13.1.1"
+        "yargs-parser": "^13.1.2"
       }
     },
     "node_modules/yargs-parser": {
-      "version": "13.1.1",
-      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-13.1.1.tgz",
-      "integrity": "sha512-oVAVsHz6uFrg3XQheFII8ESO2ssAf9luWuAd6Wexsu4F3OtIW0o8IribPXYrD4WC24LWtPrJlGy87y5udK+dxQ==",
+      "version": "13.1.2",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-13.1.2.tgz",
+      "integrity": "sha512-3lbsNRf/j+A4QuSZfDRA7HRSfWrzO0YjqTJd5kjAq37Zep1CEgaYmrH9Q3GwPiB9cHyd1Y1UwggGhJGoxipbzg==",
       "dependencies": {
         "camelcase": "^5.0.0",
         "decamelize": "^1.2.0"
@@ -955,9 +957,9 @@
       }
     },
     "node_modules/yargs/node_modules/ansi-regex": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
-      "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.1.tgz",
+      "integrity": "sha512-ILlv4k/3f6vfQ4OoP2AGvirOktlQ98ZEL1k9FaQjxa3L1abBgbuTDAdPOpvbGncC0BTVQrl+OM8xZGK6tWXt7g==",
       "engines": {
         "node": ">=6"
       }

--- a/problems/01-my-for-each.js
+++ b/problems/01-my-for-each.js
@@ -1,7 +1,8 @@
 /*******************************************************************************
-Write a function `myForEach` that accepts an array and a callback as arguments.
-The function should call the callback on each element of the array, passing in the
-element, index, and array itself. The function does not need to return any value.
+Write a function `myForEach` that accepts an array and a callback as
+arguments.  The function should call the callback on each element of the
+array, passing in the element, index, and array itself. The function
+does not need to return any value.
 
 Do not use the built in Array.forEach.
 

--- a/problems/01-my-for-each.js
+++ b/problems/01-my-for-each.js
@@ -28,7 +28,7 @@ function myForEach(array, cb) {
 
 /*****************DO NOT MODIFY ANYTHING UNDER THIS  LINE**********************/
 try {
-    module.exports = myForEach;
-} catch(e) {
-    return null;
+  module.exports = myForEach;
+} catch (e) {
+  console.error('failed to export myForEach:', e)
 }

--- a/problems/01-my-for-each.js
+++ b/problems/01-my-for-each.js
@@ -23,7 +23,7 @@ console.log(test); // ['LAIKA', 'BELKA']
 *******************************************************************************/
 
 function myForEach(array, cb) {
-    // Your code here 
+  // Your code here
 }
 
 /*****************DO NOT MODIFY ANYTHING UNDER THIS  LINE**********************/

--- a/problems/02-my-map.js
+++ b/problems/02-my-map.js
@@ -22,7 +22,7 @@ function myMap(array, cb) {
 
 /*****************DO NOT MODIFY ANYTHING UNDER THIS  LINE**********************/
 try {
-    module.exports = myMap;
-} catch(e) {
-    return null;
+  module.exports = myMap;
+} catch (e) {
+  console.error('failed to export myMap:', e);
 }

--- a/problems/02-my-map.js
+++ b/problems/02-my-map.js
@@ -17,7 +17,7 @@ console.log(result2);   // [ 'RUN!', 'FORREST!' ]
 *******************************************************************************/
 
 function myMap(array, cb) {
-    // Your code here 
+  // Your code here
 }
 
 /*****************DO NOT MODIFY ANYTHING UNDER THIS  LINE**********************/

--- a/problems/03-multi-map.js
+++ b/problems/03-multi-map.js
@@ -29,5 +29,5 @@ function multiMap(val, n, cb) {
 try {
   module.exports = multiMap;
 } catch(e) {
-  return null;
+  console.error('failed to export multiMap:', e);
 }

--- a/problems/03-multi-map.js
+++ b/problems/03-multi-map.js
@@ -22,7 +22,7 @@ console.log(result3); // hi!!!!!
 *******************************************************************************/
 
 function multiMap(val, n, cb) {
-  // Your code here 
+  // Your code here
 }
 
 /*****************DO NOT MODIFY ANYTHING UNDER THIS  LINE**********************/

--- a/problems/04-my-filter.js
+++ b/problems/04-my-filter.js
@@ -20,7 +20,7 @@ console.log(result2);      // ['choose', 'words', 'only']
 *******************************************************************************/
 
 function myFilter(array, cb) {
-    // Your code here 
+  // Your code here
 }
 
 /*****************DO NOT MODIFY ANYTHING UNDER THIS  LINE**********************/

--- a/problems/04-my-filter.js
+++ b/problems/04-my-filter.js
@@ -25,7 +25,7 @@ function myFilter(array, cb) {
 
 /*****************DO NOT MODIFY ANYTHING UNDER THIS  LINE**********************/
 try {
-    module.exports = myFilter;
-} catch(e) {
-    return null;
+  module.exports = myFilter;
+} catch (e) {
+  console.error('failed to export myFilter:', e);
 }

--- a/problems/05-selective-map.js
+++ b/problems/05-selective-map.js
@@ -42,7 +42,7 @@ function selectiveMap(array, selector, mapper) {
 
 /*****************DO NOT MODIFY ANYTHING UNDER THIS  LINE**********************/
 try {
-    module.exports = selectiveMap;
-} catch(e) {
-    return null;
+  module.exports = selectiveMap;
+} catch (e) {
+  console.error('failed to export selectiveMap:', e);
 }

--- a/problems/05-selective-map.js
+++ b/problems/05-selective-map.js
@@ -37,7 +37,7 @@ console.log(selectiveMap([-10, 4, 7, 6, -2, -9], isPositive, square));
 *******************************************************************************/
 
 function selectiveMap(array, selector, mapper) {
-    // Your code here 
+  // Your code here
 }
 
 /*****************DO NOT MODIFY ANYTHING UNDER THIS  LINE**********************/

--- a/problems/06-reject.js
+++ b/problems/06-reject.js
@@ -28,6 +28,6 @@ function reject(array, cb) {
 /*****************DO NOT MODIFY ANYTHING UNDER THIS  LINE**********************/
 try {
   module.exports = reject;
-} catch(e) {
-  return null;
+} catch (e) {
+  console.error('failed to export reject:', e);
 }

--- a/problems/06-reject.js
+++ b/problems/06-reject.js
@@ -22,7 +22,7 @@ console.log(reject(['breadth', 'GRAPH', 'depth', 'height'], hasA)); // [ 'depth'
 *******************************************************************************/
 
 function reject(array, cb) {
-  // Your code here 
+  // Your code here
 }
 
 /*****************DO NOT MODIFY ANYTHING UNDER THIS  LINE**********************/

--- a/problems/07-my-some.js
+++ b/problems/07-my-some.js
@@ -29,7 +29,7 @@ function mySome(array, cb) {
 
 /*****************DO NOT MODIFY ANYTHING UNDER THIS  LINE**********************/
 try {
-    module.exports = mySome;
-} catch(e) {
-    return null;
+  module.exports = mySome;
+} catch (e) {
+  console.error('failed to export mySome:', e);
 }

--- a/problems/07-my-some.js
+++ b/problems/07-my-some.js
@@ -24,7 +24,7 @@ console.log(result3);   // true
 *******************************************************************************/
 
 function mySome(array, cb) {
-    // Your code here 
+  // Your code here
 }
 
 /*****************DO NOT MODIFY ANYTHING UNDER THIS  LINE**********************/

--- a/problems/08-count.js
+++ b/problems/08-count.js
@@ -27,7 +27,7 @@ console.log(result4); // 0
 *******************************************************************************/
 
 function count(array, cb) {
-  // Your code here 
+  // Your code here
 }
 
 /*****************DO NOT MODIFY ANYTHING UNDER THIS  LINE**********************/

--- a/problems/08-count.js
+++ b/problems/08-count.js
@@ -34,5 +34,5 @@ function count(array, cb) {
 try {
   module.exports = count;
 } catch(e) {
-  return null;
+  console.error('failed to export count:', e);
 }

--- a/problems/09-chain-map.js
+++ b/problems/09-chain-map.js
@@ -30,7 +30,7 @@ console.log(chainMap(4, half, square));         // 4
 *******************************************************************************/
 
 function chainMap(val, ...callbacks) {
-  // Your code here 
+  // Your code here
 }
 
 /*****************DO NOT MODIFY ANYTHING UNDER THIS  LINE**********************/

--- a/problems/09-chain-map.js
+++ b/problems/09-chain-map.js
@@ -37,5 +37,5 @@ function chainMap(val, ...callbacks) {
 try {
   module.exports = chainMap;
 } catch(e) {
-  return null;
+  console.error('failed to export chainMap:', e);
 }

--- a/problems/10-my-every.js
+++ b/problems/10-my-every.js
@@ -27,7 +27,7 @@ function myEvery(array, cb) {
 
 /*****************DO NOT MODIFY ANYTHING UNDER THIS  LINE**********************/
 try {
-    module.exports = myEvery;
-  } catch(e) {
-    return null;
-  }
+  module.exports = myEvery;
+} catch (e) {
+  console.error('failed to export myEvery:', e);
+}

--- a/problems/10-my-every.js
+++ b/problems/10-my-every.js
@@ -22,7 +22,7 @@ console.log(myEvery(['book', 'door', 'pen'], hasO));    // false
 *******************************************************************************/
 
 function myEvery(array, cb) {
-    // Your code here 
+  // Your code here
 }
 
 /*****************DO NOT MODIFY ANYTHING UNDER THIS  LINE**********************/

--- a/problems/11-and-select.js
+++ b/problems/11-and-select.js
@@ -36,5 +36,5 @@ function andSelect(array, cb1, cb2) {
 try {
   module.exports = andSelect;
 } catch(e) {
-  return null;
+  console.error('failed to export andSelect:', e);
 }

--- a/problems/11-and-select.js
+++ b/problems/11-and-select.js
@@ -29,7 +29,7 @@ console.log(andSelect(['ants', 'APPLES', 'ART', 'BACON', 'arm'], isUpperCase,  s
 *******************************************************************************/
 
 function andSelect(array, cb1, cb2) {
-  // Your code here 
+  // Your code here
 }
 
 /*****************DO NOT MODIFY ANYTHING UNDER THIS  LINE**********************/

--- a/problems/12-exactly.js
+++ b/problems/12-exactly.js
@@ -35,5 +35,5 @@ function exactly(array, num, cb) {
 try {
   module.exports = exactly;
 } catch(e) {
-  return null;
+  console.error('failed to export exactly:', e);
 }

--- a/problems/12-exactly.js
+++ b/problems/12-exactly.js
@@ -28,7 +28,7 @@ console.log(result4); // true
 *******************************************************************************/
 
 function exactly(array, num, cb) {
-  // Your code here 
+  // Your code here
 }
 
 /*****************DO NOT MODIFY ANYTHING UNDER THIS  LINE**********************/

--- a/problems/13-min-value-callback.js
+++ b/problems/13-min-value-callback.js
@@ -1,8 +1,9 @@
 /*******************************************************************************
-Write a function `minValueCallback` that accepts an array and an optional callback as arguments.
-If a callback is not passed in, then the function should return the smallest
-value in the array. If a callback is passed in, then the function should return
-the result of the smallest value being passed into the given callback.
+Write a function `minValueCallback` that accepts an array and an
+optional callback as arguments.  If a callback is not passed in, then
+the function should return the smallest value in the array. If a
+callback is passed in, then the function should return the result of
+the smallest value being passed into the given callback.
 
 Examples:
 console.log(minValueCallback([64, 25, 49, 9, 100]));             // 9

--- a/problems/13-min-value-callback.js
+++ b/problems/13-min-value-callback.js
@@ -12,7 +12,7 @@ console.log(minValueCallback([64, 25, 49, 9, 100], Math.sqrt));  // 3
 *******************************************************************************/
 
 function minValueCallback(array, cb) {
-    // Your code here 
+  // Your code here
 }
 
 /*****************DO NOT MODIFY ANYTHING UNDER THIS  LINE**********************/

--- a/problems/13-min-value-callback.js
+++ b/problems/13-min-value-callback.js
@@ -18,6 +18,6 @@ function minValueCallback(array, cb) {
 /*****************DO NOT MODIFY ANYTHING UNDER THIS  LINE**********************/
 try {
   module.exports = minValueCallback;
-} catch(e) {
-  return null;
+} catch (e) {
+  console.error('failed to export minValueCallback:', e);
 }

--- a/problems/14-map-mutator.js
+++ b/problems/14-map-mutator.js
@@ -19,7 +19,7 @@ console.log(arr2); // [ 0, 9, 20 ]
 *******************************************************************************/
 
 function mapMutator(array, cb) {
-  // Your code here 
+  // Your code here
 }
 
 /*****************DO NOT MODIFY ANYTHING UNDER THIS  LINE**********************/

--- a/problems/14-map-mutator.js
+++ b/problems/14-map-mutator.js
@@ -26,5 +26,5 @@ function mapMutator(array, cb) {
 try {
   module.exports = mapMutator;
 } catch(e) {
-  return null;
+  console.error('failed to export mapMutator:', e);
 }

--- a/problems/15-sentence-mapper.js
+++ b/problems/15-sentence-mapper.js
@@ -26,7 +26,7 @@ console.log(result2); // 'ths s prtty cl rght'
 *******************************************************************************/
 
 let sentenceMapper = function (sentence, cb) {
-  // Your code here 
+  // Your code here
 };
 
 /*****************DO NOT MODIFY ANYTHING UNDER THIS  LINE**********************/

--- a/problems/15-sentence-mapper.js
+++ b/problems/15-sentence-mapper.js
@@ -33,5 +33,5 @@ let sentenceMapper = function (sentence, cb) {
 try {
   module.exports = sentenceMapper;
 } catch (e) {
-  return null;
+  console.error('failed to export sentenceMapper:', e);
 }

--- a/problems/16-suffix-cipher.js
+++ b/problems/16-suffix-cipher.js
@@ -32,7 +32,7 @@ console.log(suffixCipher('incremental progress is very instrumental', cipher2));
 *******************************************************************************/
 
 function suffixCipher(sentence, cipher) {
-  // Your code here 
+  // Your code here
 }
 
 /*****************DO NOT MODIFY ANYTHING UNDER THIS  LINE**********************/

--- a/problems/16-suffix-cipher.js
+++ b/problems/16-suffix-cipher.js
@@ -38,6 +38,6 @@ function suffixCipher(sentence, cipher) {
 /*****************DO NOT MODIFY ANYTHING UNDER THIS  LINE**********************/
 try {
   module.exports = suffixCipher;
-} catch(e) {
-  return null;
+} catch (e) {
+  console.error('failed to export suffixCipher:', e);
 }

--- a/problems/17-xor-select.js
+++ b/problems/17-xor-select.js
@@ -32,7 +32,7 @@ console.log(
 *******************************************************************************/
 
 let xorSelect = function(array, cb1, cb2) {
-  // Your code here 
+  // Your code here
 };
 
 /*****************DO NOT MODIFY ANYTHING UNDER THIS  LINE**********************/

--- a/problems/17-xor-select.js
+++ b/problems/17-xor-select.js
@@ -38,6 +38,6 @@ let xorSelect = function(array, cb1, cb2) {
 /*****************DO NOT MODIFY ANYTHING UNDER THIS  LINE**********************/
 try {
   module.exports = xorSelect;
-} catch(e) {
-  return null;
+} catch (e) {
+  console.error('failed to export xorSelect:', e);
 }

--- a/problems/18-one.js
+++ b/problems/18-one.js
@@ -39,7 +39,7 @@ console.log(result6);   // true
 *******************************************************************************/
 
 function one(array, cb) {
-  // Your code here 
+  // Your code here
 }
 
 /*****************DO NOT MODIFY ANYTHING UNDER THIS  LINE**********************/

--- a/problems/18-one.js
+++ b/problems/18-one.js
@@ -45,6 +45,6 @@ function one(array, cb) {
 /*****************DO NOT MODIFY ANYTHING UNDER THIS  LINE**********************/
 try {
   module.exports = one;
-} catch(e) {
-  return null;
+} catch (e) {
+  console.error('failed to export one:', e);
 }

--- a/problems/18-one.js
+++ b/problems/18-one.js
@@ -1,8 +1,9 @@
 /*******************************************************************************
-Write a function `one` that accepts an array and a callback as arguments. The
-function should call the callback for each element of the array, passing in the
-element and its index. The function should return a boolean indicating whether
-or not exactly one element of the array results in true when passed into the callback.
+Write a function `one` that accepts an array and a callback as
+arguments. The function should call the callback for each element of
+the array, passing in the element and its index. The function should
+return a boolean indicating whether or not exactly one element of the
+array results in true when passed into the callback.
 
 Examples:
 

--- a/problems/19-greater-callback-value.js
+++ b/problems/19-greater-callback-value.js
@@ -26,5 +26,5 @@ function greaterCallbackValue(val, cb1, cb2) {
 try {
   module.exports = greaterCallbackValue;
 } catch (e) {
-  return null;
+  console.error('failed to export greaterCallbackValue:', e);
 }

--- a/problems/19-greater-callback-value.js
+++ b/problems/19-greater-callback-value.js
@@ -19,7 +19,7 @@ console.log(greaterCallbackValue(9, Math.sqrt, doubler));   // 18
 *******************************************************************************/
 
 function greaterCallbackValue(val, cb1, cb2) {
-  // Your code here 
+  // Your code here
 }
 
 /*****************DO NOT MODIFY ANYTHING UNDER THIS  LINE**********************/

--- a/problems/20-none.js
+++ b/problems/20-none.js
@@ -36,5 +36,5 @@ function none(array, cb) {
 try {
   module.exports = none;
 } catch (e) {
-  return null;
+  console.error('failed to export none:', e);
 }

--- a/problems/20-none.js
+++ b/problems/20-none.js
@@ -29,7 +29,7 @@ console.log(result4);   // false
 *******************************************************************************/
 
 function none(array, cb) {
-  // Your code here 
+  // Your code here
 }
 
 /*****************DO NOT MODIFY ANYTHING UNDER THIS  LINE**********************/

--- a/problems/21-at-most.js
+++ b/problems/21-at-most.js
@@ -21,7 +21,7 @@ console.log(atMost(['boat', 'arc', 'cat', 'car', 'academy'], 1, startsWithA));  
 *******************************************************************************/
 
 function atMost(array, max, cb) {
-  // Your code here 
+  // Your code here
 }
 
 /*****************DO NOT MODIFY ANYTHING UNDER THIS  LINE**********************/

--- a/problems/21-at-most.js
+++ b/problems/21-at-most.js
@@ -28,5 +28,5 @@ function atMost(array, max, cb) {
 try {
   module.exports = atMost;
 } catch (e) {
-  return null;
+  console.error('failed to export atMost:', e);
 }

--- a/problems/22-first-index.js
+++ b/problems/22-first-index.js
@@ -23,7 +23,7 @@ console.log(result3); // -1
 *******************************************************************************/
 
 function firstIndex(array, cb) {
-  // Your code here 
+  // Your code here
 }
 
 /*****************DO NOT MODIFY ANYTHING UNDER THIS  LINE**********************/

--- a/problems/22-first-index.js
+++ b/problems/22-first-index.js
@@ -29,6 +29,6 @@ function firstIndex(array, cb) {
 /*****************DO NOT MODIFY ANYTHING UNDER THIS  LINE**********************/
 try {
   module.exports = firstIndex;
-} catch(e) {
-  return null;
+} catch (e) {
+  console.error('failed to export firstIndex:', e);
 }

--- a/problems/23-alternating-map.js
+++ b/problems/23-alternating-map.js
@@ -35,7 +35,7 @@ console.log(alternatingMap(['hEy', 'EVERYone', 'whats', 'uP??'], yell, whisper))
 *******************************************************************************/
 
 function alternatingMap(array, cb1, cb2) {
-  // Your code here 
+  // Your code here
 }
 
 /*****************DO NOT MODIFY ANYTHING UNDER THIS  LINE**********************/

--- a/problems/23-alternating-map.js
+++ b/problems/23-alternating-map.js
@@ -42,5 +42,5 @@ function alternatingMap(array, cb1, cb2) {
 try {
   module.exports = alternatingMap;
 } catch(e) {
-  return null;
+  console.error('failed to export alternatingMap:', e);
 }

--- a/problems/24-my-simple-reduce.js
+++ b/problems/24-my-simple-reduce.js
@@ -38,5 +38,5 @@ function mySimpleReduce(array, cb) {
 try {
   module.exports = mySimpleReduce;
 } catch (e) {
-  return null;
+  console.error('failed to export mySimpleReduce:', e);
 }

--- a/problems/24-my-simple-reduce.js
+++ b/problems/24-my-simple-reduce.js
@@ -31,7 +31,7 @@ console.log(result3); // 8
 *******************************************************************************/
 
 function mySimpleReduce(array, cb) {
-  // Your code here 
+  // Your code here
 }
 
 /*****************DO NOT MODIFY ANYTHING UNDER THIS  LINE**********************/


### PR DESCRIPTION
the most meaningful change in this pull request is to indicate failure to export function.  this replaces an attempt to return null at the top level, which is invalid.

other changes include making explanations fit within the comment stars, removing stray end-of-line whitespace, and my favorite, standardizing the indent space count.  some files had 4, some had 2.  i was not able to quickly separate this last change into its own commit, so it's mixed with the others.